### PR TITLE
Patch: Update config.toml

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,4 +1,2 @@
 [build]
-rustflags = [
-    "-Dwarnings", "-Dfuture-incompatible", "-Dnonstandard-style", "-Drust-2018-idioms", "-Dunused" , "-Dclippy::unwrap_used"
-]
+rustflags = ["-Wall", "-Wextra", "-Wpedantic", "-Wfuture-incompatible", "-Wnonstandard-style", "-Wunused", "-Dclippy::unwrap_used"]


### PR DESCRIPTION
Above configuration file uses the -Wall, -Wextra, and -Wpedantic flags to enable all available warning messages, and the -Wfuture-incompatible, -Wnonstandard-style, and -Wunused flags to enable specific warnings for code that may become incompatible with future versions of Rust, code that deviates from standard Rust style guidelines, and unused code elements, respectively. Finally, the -Dclippy::unwrap_used flag enables warnings for the use of the unwrap() method.