### PR TITLE
Allow `EntryPointOffset` to be serde'd from int/string

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,6 +9,8 @@ pub mod serde_utils;
 pub mod state;
 pub mod transaction;
 
+use std::num::ParseIntError;
+
 use serde_utils::InnerDeserializationError;
 
 /// The error type returned by StarknetApi.
@@ -20,4 +22,7 @@ pub enum StarknetApiError {
     #[error("Out of range {string}.")]
     /// An error for when a value is out of range.
     OutOfRange { string: String },
+    /// Error when serializing into number.
+    #[error(transparent)]
+    ParseIntError(#[from] ParseIntError),
 }

--- a/src/state.rs
+++ b/src/state.rs
@@ -4,15 +4,15 @@ mod state_test;
 
 use std::collections::HashMap;
 use std::fmt::Debug;
-use std::mem;
 
 use indexmap::IndexMap;
-use serde::{Deserialize, Serialize};
+use serde::de::Error as DeserializationError;
+use serde::{Deserialize, Deserializer, Serialize};
+use serde_json::Value;
 
 use crate::block::{BlockHash, BlockNumber};
 use crate::core::{ClassHash, ContractAddress, EntryPointSelector, GlobalRoot, Nonce, PatriciaKey};
 use crate::hash::{StarkFelt, StarkHash};
-use crate::serde_utils::bytes_from_hex_str;
 use crate::StarknetApiError;
 
 /// The differences between two states before and after a block with hash block_hash
@@ -106,23 +106,29 @@ pub struct EntryPoint {
 #[derive(
     Debug, Copy, Clone, Default, Eq, PartialEq, Hash, Deserialize, Serialize, PartialOrd, Ord,
 )]
-#[serde(try_from = "String", into = "String")]
-pub struct EntryPointOffset(pub usize);
-
+pub struct EntryPointOffset(#[serde(deserialize_with = "number_or_string")] pub usize);
 impl TryFrom<String> for EntryPointOffset {
     type Error = StarknetApiError;
 
     fn try_from(value: String) -> Result<Self, Self::Error> {
-        const SIZE_OF_USIZE: usize = mem::size_of::<usize>();
-        let bytes = bytes_from_hex_str::<SIZE_OF_USIZE, true>(value.as_str())?;
-        Ok(Self(usize::from_be_bytes(bytes)))
+        Ok(Self(hex_string_try_into_usize(&value)?))
     }
 }
 
-impl From<EntryPointOffset> for String {
-    fn from(value: EntryPointOffset) -> Self {
-        format!("0x{:x}", value.0)
-    }
+pub fn number_or_string<'de, D: Deserializer<'de>>(deserializer: D) -> Result<usize, D::Error> {
+    let usize_value = match Value::deserialize(deserializer)? {
+        Value::Number(number) => {
+            number.as_u64().ok_or(DeserializationError::custom("Cannot cast number to usize."))?
+                as usize
+        }
+        Value::String(s) => hex_string_try_into_usize(&s).map_err(DeserializationError::custom)?,
+        _ => return Err(DeserializationError::custom("Cannot cast value into usize.")),
+    };
+    Ok(usize_value)
+}
+
+fn hex_string_try_into_usize(hex_string: &str) -> Result<usize, std::num::ParseIntError> {
+    usize::from_str_radix(hex_string.trim_start_matches("0x"), 16)
 }
 
 /// A program corresponding to a [ContractClass](`crate::state::ContractClass`).

--- a/src/state_test.rs
+++ b/src/state_test.rs
@@ -1,9 +1,24 @@
+use std::collections::HashMap;
+
+use serde_json::json;
+
 use crate::state::EntryPointOffset;
 
 #[test]
-fn entry_point_offset_from_str() {
+fn entry_point_offset_from_json_str() {
+    let data = r#"
+        {
+            "offset_1":  2 ,
+            "offset_2": "0x7b"
+        }"#;
+    let offsets: HashMap<String, EntryPointOffset> = serde_json::from_str(data).unwrap();
+
+    assert_eq!(EntryPointOffset(2), offsets["offset_1"]);
+    assert_eq!(EntryPointOffset(123), offsets["offset_2"]);
+}
+
+#[test]
+fn entry_point_offset_into_json_str() {
     let offset = EntryPointOffset(123);
-    let as_str: String = offset.into();
-    assert_eq!("0x7b", as_str);
-    assert_eq!(EntryPointOffset::try_from(as_str).unwrap(), offset);
+    assert_eq!(json!(offset), json!(123));
 }


### PR DESCRIPTION
- In new releases offsets will be numbers, whereas in the past they were
  strings.
- Simplified casting logic.
- Remove `serde from=` since it isn't relevant.
- Added a test for the `into` case.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-api/33)
<!-- Reviewable:end -->
