### PR TITLE
Fix: replace web3 with primitive-types

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,8 @@ serde = { version = "1.0.130", features = ["derive", "rc"] }
 serde_json = { version = "1.0.81" }
 starknet-crypto = { version = "0.2.0" }
 thiserror = { version = "1.0.31" }
-web3 = { version = "0.18.0" }
-derive_more = {version = "0.99.17"}
+primitive-types = { version = "0.12.1", features = ["serde"] }
+derive_more = { version = "0.99.17" }
 
 [dev-dependencies]
 assert_matches = { version = "1.5.0" }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,8 +1,8 @@
 use std::fmt::Display;
 use std::sync::Arc;
 
+use primitive_types::H160;
 use serde::{Deserialize, Serialize};
-use web3::types::H160;
 
 use crate::block::{BlockHash, BlockNumber};
 use crate::core::{ClassHash, CompiledClassHash, ContractAddress, EntryPointSelector, Nonce};


### PR DESCRIPTION
The _web3_ version currently in use has known vulnerabilities that trigger _dependabot_ alerts. This PR replaces it, as it was only used for its `H160` type - a reexport of _primitive-types_ with the _"serde"_ feature.

Alternatively, we could update the _web3_ dependency to the latest version and disable default features. This would leave us the option of later enabling those features as needed.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-api/47)
<!-- Reviewable:end -->
