### PR TITLE
feat(transaction): derive  for transaction version wrapper enum types

### DIFF
--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,6 +1,7 @@
 use std::fmt::Display;
 use std::sync::Arc;
 
+use derive_more::From;
 use serde::{Deserialize, Serialize};
 use web3::types::H160;
 
@@ -183,7 +184,7 @@ pub struct InvokeTransactionV1 {
     pub calldata: Calldata,
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, PartialOrd, Ord)]
+#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, PartialOrd, Ord, From)]
 pub enum InvokeTransaction {
     V0(InvokeTransactionV0),
     V1(InvokeTransactionV1),


### PR DESCRIPTION
It's useful to have this kind of wrapper type implement `Form`

```rust
#[derive(Debug, Clone, Eq, PartialEq, Hash, Deserialize, Serialize, PartialOrd, Ord)]
pub enum DeclareTransaction {
    V0(DeclareTransactionV0V1),
    V1(DeclareTransactionV0V1),
    V2(DeclareTransactionV2),
}
```

Because V0 and V1 are internally the same types, it is not possible to derive `From` on this enum. Which is a bit weird. Did you consider something like this:
```rust
pub enum DeclareTransaction {
    V0V1(DeclareTransactionV0V1),
    V2(DeclareTransactionV2),
}
```

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-api/48)
<!-- Reviewable:end -->
