### PR TITLE
Fix: default serialization for FunctionAbiEntryType

### DIFF
--- a/src/deprecated_contract_class.rs
+++ b/src/deprecated_contract_class.rs
@@ -56,7 +56,7 @@ pub enum FunctionAbiEntryType {
     L1Handler,
     #[serde(rename = "function")]
     #[default]
-    Regular,
+    Function,
 }
 
 /// A function abi entry.

--- a/src/deprecated_contract_class.rs
+++ b/src/deprecated_contract_class.rs
@@ -54,7 +54,7 @@ pub enum FunctionAbiEntryType {
     Constructor,
     #[serde(rename = "l1_handler")]
     L1Handler,
-    #[serde(rename = "regular")]
+    #[serde(rename = "function")]
     #[default]
     Regular,
 }


### PR DESCRIPTION
When deserializing a "deprecated" Cairo contract class using the starknet-api and compiling with starknet-compile version 0.11, the deserializer expects the value of the "type" attribute of the ABI schema for functions to be "regular". However, the JSON output of the Cairo program compilation contains an ABI schema with the entry type being "function". This causes the deserialization to fail when trying to read a Cairo contract class.
This PR provides a fix to this issue by changing the default value expected in FunctionAbiEntryType to "function" instead of "regular".


<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-api/50)
<!-- Reviewable:end -->
