### PR TITLE
Implement TryFrom<CasmContractEntryPoint> for EntryPoint

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 testing = []
 
 [dependencies]
+cairo-lang-starknet = { git = "https://github.com/starkware-libs/cairo", rev = "2390363" }
 hex = { version = "0.4.3" }
 indexmap = { version = "1.9.2", features = ["serde"] }
 once_cell = { version = "1.16.0" }

--- a/src/deprecated_contract_class.rs
+++ b/src/deprecated_contract_class.rs
@@ -1,5 +1,6 @@
 use std::collections::HashMap;
 
+use cairo_lang_starknet::casm_contract_class::CasmContractEntryPoint;
 use serde::de::Error as DeserializationError;
 use serde::{Deserialize, Deserializer, Serialize};
 use serde_json::Value;
@@ -123,6 +124,17 @@ pub enum EntryPointType {
 pub struct EntryPoint {
     pub selector: EntryPointSelector,
     pub offset: EntryPointOffset,
+}
+
+impl TryFrom<CasmContractEntryPoint> for EntryPoint {
+    type Error = StarknetApiError;
+
+    fn try_from(value: CasmContractEntryPoint) -> Result<Self, Self::Error> {
+        Ok(EntryPoint {
+            selector: EntryPointSelector(value.selector.to_str_radix(16).as_str().try_into()?),
+            offset: EntryPointOffset(value.offset),
+        })
+    }
 }
 
 #[derive(Debug, Clone, Default, Eq, PartialEq, Deserialize, Serialize)]

--- a/src/hash.rs
+++ b/src/hash.rs
@@ -141,7 +141,8 @@ impl TryFrom<PrefixedBytesAsHex<32_usize>> for StarkFelt {
 impl TryFrom<&str> for StarkFelt {
     type Error = StarknetApiError;
     fn try_from(val: &str) -> Result<Self, Self::Error> {
-        let bytes = bytes_from_hex_str::<32, true>(val)?;
+        let val = val.trim_start_matches("0x");
+        let bytes = bytes_from_hex_str::<32, false>(val)?;
         Self::new(bytes)
     }
 }


### PR DESCRIPTION
This is necessary to properly implement: https://github.com/starkware-libs/blockifier/pull/423

It enables conversion of Cairo 1.0 casm artifacts into the blockfier representation such that they can be executed by blockifier

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-api/52)
<!-- Reviewable:end -->
