### PR TITLE
Workaround `genco` bug

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,6 +13,9 @@ testing = []
 [dependencies]
 cairo-lang-starknet = "2.1.0-rc0"
 derive_more = "0.99.17"
+# TODO(Gilad): Remove `genco` dep once the issue with its 0.17.7 release
+# is fixed, or no longer a dependency of cairo-lang-starknet.
+genco = "=0.17.6"
 hex = "0.4.3"
 indexmap = { version = "1.9.2", features = ["serde"] }
 once_cell = "1.17.1"


### PR DESCRIPTION
Looks like `genco = 0.17.7` from last month breaks compilation. This is a dependency of `cairo-lang-starknet`, which is why we need the cargo-udeps flag (it isn't used inside starknet-api at all).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-api/145)
<!-- Reviewable:end -->
