### PR TITLE
Release 0.6.0-rc1: includes revert of `Block` changes + fix `genco`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "starknet_api"
-version = "0.6.0-rc0"
+version = "0.6.0-rc1"
 edition = "2021"
 repository = "https://github.com/starkware-libs/starknet-api"
 license = "Apache-2.0"
@@ -13,9 +13,6 @@ testing = []
 [dependencies]
 cairo-lang-starknet = "2.1.0-rc0"
 derive_more = "0.99.17"
-# TODO(Gilad): Remove `genco` dep once the issue with its 0.17.7 release
-# is fixed, or no longer a dependency of cairo-lang-starknet.
-genco = "=0.17.6"
 hex = "0.4.3"
 indexmap = { version = "1.9.2", features = ["serde"] }
 once_cell = "1.17.1"


### PR DESCRIPTION
`genco` fixed the buggy 0.17.7 3 hours ago in version 0.17.8.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-api/149)
<!-- Reviewable:end -->
