### PR TITLE
Fixate parity_scale_codec on 3.6.5 to fix error in udeps

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,10 @@ derive_more = "0.99.17"
 hex = "0.4.3"
 indexmap = { version = "1.9.2", features = ["serde"] }
 once_cell = "1.17.1"
+# fixating the version of parity-scale-codec and parity-scale-codec-derive due to an error in udeps.
+# TODO: Remove this once udeps is fixed.
+parity-scale-codec = "=3.6.5"
+parity-scale-codec-derive = "=3.6.5"
 primitive-types = { version = "0.12.1", features = ["serde"] }
 serde = { version = "1.0.130", features = ["derive", "rc"] }
 serde_json = "1.0.81"


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-api/158)
<!-- Reviewable:end -->
