### PR TITLE
feat: add and sub traits for StorageKey

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -158,7 +158,8 @@ impl std::ops::Add<i128> for StorageKey {
         let base_address = Into::<FieldElement>::into(*self.0.key()) + rhs;
 
         StorageKey(
-            PatriciaKey::try_from(StarkFelt::from(base_address)).expect("storage key out of range"),
+            PatriciaKey::try_from(StarkFelt::from(base_address))
+                .expect("attempt to add to storage key with overflow"),
         )
     }
 }
@@ -173,7 +174,8 @@ impl std::ops::Add<StorageKey> for i128 {
         let base_address = lhs + Into::<FieldElement>::into(*rhs.0.key());
 
         StorageKey(
-            PatriciaKey::try_from(StarkFelt::from(base_address)).expect("storage key out of range"),
+            PatriciaKey::try_from(StarkFelt::from(base_address))
+                .expect("attempt to add to storage key with overflow"),
         )
     }
 }

--- a/src/state_test.rs
+++ b/src/state_test.rs
@@ -3,6 +3,7 @@ use std::collections::HashMap;
 use serde_json::json;
 
 use crate::deprecated_contract_class::EntryPointOffset;
+use crate::state::StorageKey;
 
 #[test]
 fn entry_point_offset_from_json_str() {
@@ -21,4 +22,38 @@ fn entry_point_offset_from_json_str() {
 fn entry_point_offset_into_json_str() {
     let offset = EntryPointOffset(123);
     assert_eq!(json!(offset), json!(format!("{:#x}", offset.0)));
+}
+
+#[test]
+fn offset_storage_key_add_rhs_ok() {
+    let key = StorageKey::from(123u128);
+    let offset = -23;
+    let expected = StorageKey::from(100u128);
+    let result: StorageKey = key + offset;
+    assert_eq!(expected, result);
+}
+
+#[test]
+#[should_panic(expected = "storage key out of range")]
+fn offset_storage_key_add_rhs_err() {
+    let key = StorageKey::from(123u128);
+    let offset = -124;
+    let _: StorageKey = key + offset;
+}
+
+#[test]
+fn offset_storage_key_add_lhs_ok() {
+    let key = StorageKey::from(123u128);
+    let offset = -23;
+    let expected = StorageKey::from(100u128);
+    let result: StorageKey = offset + key;
+    assert_eq!(expected, result);
+}
+
+#[test]
+#[should_panic(expected = "storage key out of range")]
+fn offset_storage_key_add_lhs_err() {
+    let key = StorageKey::from(123u128);
+    let offset = -124;
+    let _: StorageKey = offset + key;
 }

--- a/src/state_test.rs
+++ b/src/state_test.rs
@@ -34,7 +34,7 @@ fn offset_storage_key_add_rhs_ok() {
 }
 
 #[test]
-#[should_panic(expected = "storage key out of range")]
+#[should_panic(expected = "attempt to add to storage key with overflow")]
 fn offset_storage_key_add_rhs_err() {
     let key = StorageKey::from(123u128);
     let offset = -124;
@@ -51,7 +51,7 @@ fn offset_storage_key_add_lhs_ok() {
 }
 
 #[test]
-#[should_panic(expected = "storage key out of range")]
+#[should_panic(expected = "attempt to add to storage key with overflow")]
 fn offset_storage_key_add_lhs_err() {
     let key = StorageKey::from(123u128);
     let offset = -124;


### PR DESCRIPTION
Implement the `Add` and `Sub` traits for StorageKey in order to easily offset a StorageKey instance. The addition or subtraction will panic in case of a underflow/overflow.