### PR TITLE
fix(ContractClass): match pythonic name for entry_points_by_type

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -168,7 +168,7 @@ impl_from_through_intermediate!(u128, StorageKey, u8, u16, u32, u64);
 #[derive(Debug, Clone, Default, Eq, PartialEq, Deserialize, Serialize)]
 pub struct ContractClass {
     pub sierra_program: Vec<StarkFelt>,
-    pub entry_point_by_type: HashMap<EntryPointType, Vec<EntryPoint>>,
+    pub entry_points_by_type: HashMap<EntryPointType, Vec<EntryPoint>>,
     pub abi: String,
 }
 


### PR DESCRIPTION
Currently I can't use `ContractClass.load(...)` because the fields don't match the name. It seems to be a typo so fixing it

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-api/171)
<!-- Reviewable:end -->
