### PR TITLE
fix: make BlockNumber::next safe

### DIFF
--- a/src/block.rs
+++ b/src/block.rs
@@ -132,10 +132,17 @@ pub struct BlockHash(pub StarkHash);
 pub struct BlockNumber(pub u64);
 
 impl BlockNumber {
-    pub fn next(&self) -> BlockNumber {
+    /// Returns the next block number, without checking if it's in range.
+    pub fn unchecked_next(&self) -> BlockNumber {
         BlockNumber(self.0 + 1)
     }
 
+    /// Returns the next block number, or None if the next block number is out of range.
+    pub fn next(&self) -> Option<Self> {
+        Some(Self(self.0.checked_add(1)?))
+    }
+
+    /// Returns the previous block number, or None if the previous block number is out of range.
     pub fn prev(&self) -> Option<BlockNumber> {
         match self.0 {
             0 => None,
@@ -143,6 +150,7 @@ impl BlockNumber {
         }
     }
 
+    /// Returns an iterator over the block numbers from self to up_to (exclusive).
     pub fn iter_up_to(&self, up_to: Self) -> impl Iterator<Item = BlockNumber> {
         let range = self.0..up_to.0;
         range.map(Self)

--- a/src/state.rs
+++ b/src/state.rs
@@ -108,8 +108,9 @@ impl StateNumber {
     }
 
     /// The state at the end of the block.
-    pub fn right_after_block(block_number: BlockNumber) -> StateNumber {
-        StateNumber(block_number.next())
+    /// Returns None if the block number is the maximum value.
+    pub fn right_after_block(block_number: BlockNumber) -> Option<StateNumber> {
+        Some(StateNumber(block_number.next()?))
     }
 
     pub fn is_before(&self, block_number: BlockNumber) -> bool {


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-api/189)
<!-- Reviewable:end -->
