### PR TITLE
fix: add unchecked_right_after_block method to StateNumber

### DIFF
--- a/src/state.rs
+++ b/src/state.rs
@@ -113,6 +113,12 @@ impl StateNumber {
         Some(StateNumber(block_number.next()?))
     }
 
+    /// The state at the end of the block.
+    /// Panics if the block number is the maximum value.
+    pub fn unchecked_right_after_block(block_number: BlockNumber) -> StateNumber {
+        StateNumber(block_number.unchecked_next())
+    }
+
     pub fn is_before(&self, block_number: BlockNumber) -> bool {
         self.0 <= block_number
     }


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-api/190)
<!-- Reviewable:end -->
