### PR TITLE
feat(transaction): convert external to internal tx

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -26,6 +26,7 @@ strum = "0.24.1"
 strum_macros = "0.24.3"
 thiserror = "1.0.31"
 
+
 [dev-dependencies]
 assert_matches = "1.5.0"
 rstest = "0.17.0"

--- a/src/external_transaction.rs
+++ b/src/external_transaction.rs
@@ -6,32 +6,50 @@ use std::collections::HashMap;
 
 use serde::{Deserialize, Serialize};
 
-use crate::core::{ClassHash, CompiledClassHash, ContractAddress, Nonce};
+use crate::core::{
+    calculate_contract_address, ChainId, ClassHash, CompiledClassHash, ContractAddress, Nonce,
+};
 use crate::data_availability::DataAvailabilityMode;
-use crate::state::{EntryPoint, EntryPointType};
+use crate::internal_transaction::{
+    ClassInfo, InternalDeclareTransaction, InternalDeployAccountTransaction,
+    InternalInvokeTransaction, InternalTransaction,
+};
+use crate::state::{ContractClass as InternalContractClass, EntryPoint, EntryPointType};
 use crate::transaction::{
     AccountDeploymentData, Calldata, ContractAddressSalt, PaymasterData, ResourceBoundsMapping,
-    Tip, TransactionSignature,
+    Tip, TransactionHasher, TransactionSignature, TransactionVersion,
 };
 
-/// An external transaction.
+/// A transaction that can be added to Starknet through the Starknet gateway.
+/// It has a serialization format that the Starknet gateway accepts in the `add_transaction`
+/// HTTP method.
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(tag = "type")]
 pub enum ExternalTransaction {
-    /// A declare transaction.
     #[serde(rename = "DECLARE")]
     Declare(ExternalDeclareTransaction),
-    /// A deploy account transaction.
     #[serde(rename = "DEPLOY_ACCOUNT")]
     DeployAccount(ExternalDeployAccountTransaction),
-    /// An invoke transaction.
     #[serde(rename = "INVOKE_FUNCTION")]
     Invoke(ExternalInvokeTransaction),
 }
 
-/// A declare transaction that can be added to Starknet through the Starknet gateway.
-/// It has a serialization format that the Starknet gateway accepts in the `add_transaction`
-/// HTTP method.
+impl ExternalTransaction {
+    pub fn into_internal(self, chain_id: &ChainId) -> InternalTransaction {
+        match self {
+            ExternalTransaction::Declare(tx) => {
+                InternalTransaction::Declare(tx.into_internal(chain_id))
+            }
+            ExternalTransaction::DeployAccount(tx) => {
+                InternalTransaction::DeployAccount(tx.into_internal(chain_id))
+            }
+            ExternalTransaction::Invoke(tx) => {
+                InternalTransaction::Invoke(tx.into_internal(chain_id))
+            }
+        }
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(tag = "version")]
 pub enum ExternalDeclareTransaction {
@@ -39,9 +57,14 @@ pub enum ExternalDeclareTransaction {
     V3(ExternalDeclareTransactionV3),
 }
 
-/// A deploy account transaction that can be added to Starknet through the Starknet gateway.
-/// It has a serialization format that the Starknet gateway accepts in the `add_transaction`
-/// HTTP method.
+impl ExternalDeclareTransaction {
+    pub fn into_internal(self, chain_id: &ChainId) -> InternalDeclareTransaction {
+        match self {
+            ExternalDeclareTransaction::V3(tx) => tx.into_internal(chain_id),
+        }
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(tag = "version")]
 pub enum ExternalDeployAccountTransaction {
@@ -49,9 +72,14 @@ pub enum ExternalDeployAccountTransaction {
     V3(ExternalDeployAccountTransactionV3),
 }
 
-/// An invoke transaction that can be added to Starknet through the Starknet gateway.
-/// It has a serialization format that the Starknet gateway accepts in the `add_transaction`
-/// HTTP method.
+impl ExternalDeployAccountTransaction {
+    pub fn into_internal(self, chain_id: &ChainId) -> InternalDeployAccountTransaction {
+        match self {
+            ExternalDeployAccountTransaction::V3(tx) => tx.into_internal(chain_id),
+        }
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(tag = "version")]
 pub enum ExternalInvokeTransaction {
@@ -59,10 +87,14 @@ pub enum ExternalInvokeTransaction {
     V3(ExternalInvokeTransactionV3),
 }
 
-/// A declare transaction of a Cairo-v1 contract class that can be added to Starknet through the
-/// Starknet gateway.
-/// It has a serialization format that the Starknet gateway accepts in the `add_transaction`
-/// HTTP method.
+impl ExternalInvokeTransaction {
+    fn into_internal(self, chain_id: &ChainId) -> InternalInvokeTransaction {
+        match self {
+            ExternalInvokeTransaction::V3(tx) => tx.into_internal(chain_id),
+        }
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ExternalDeclareTransactionV3 {
@@ -79,9 +111,41 @@ pub struct ExternalDeclareTransactionV3 {
     pub account_deployment_data: AccountDeploymentData,
 }
 
-/// A deploy account transaction that can be added to Starknet through the Starknet gateway.
-/// It has a serialization format that the Starknet gateway accepts in the `add_transaction`
-/// HTTP method.
+impl ExternalDeclareTransactionV3 {
+    fn into_internal(self, chain_id: &ChainId) -> InternalDeclareTransaction {
+        let class_hash = calculate_class_hash();
+
+        let tx =
+            crate::transaction::DeclareTransaction::V3(crate::transaction::DeclareTransactionV3 {
+                resource_bounds: self.resource_bounds,
+                tip: self.tip,
+                signature: self.signature,
+                nonce: self.nonce,
+                class_hash,
+                compiled_class_hash: self.compiled_class_hash,
+                sender_address: self.sender_address,
+                nonce_data_availability_mode: self.nonce_data_availability_mode,
+                fee_data_availability_mode: self.fee_data_availability_mode,
+                paymaster_data: self.paymaster_data,
+                account_deployment_data: self.account_deployment_data,
+            });
+
+        let tx_hash = tx.calculate_transaction_hash(chain_id, &TransactionVersion::THREE).unwrap();
+        InternalDeclareTransaction {
+            tx,
+            tx_hash,
+            only_query: false,
+            // TODO: convert contract class to Internal type.
+            // TODO: calculate abi and sierra program lengths.
+            class_info: ClassInfo {
+                abi_length: 0,
+                contract_class: InternalContractClass::default(),
+                sierra_program_length: 0,
+            },
+        }
+    }
+}
+
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ExternalDeployAccountTransactionV3 {
@@ -97,10 +161,35 @@ pub struct ExternalDeployAccountTransactionV3 {
     pub paymaster_data: PaymasterData,
 }
 
-/// An invoke account transaction that can be added to Starknet through the Starknet gateway.
-/// The invoke is a V3 transaction.
-/// It has a serialization format that the Starknet gateway accepts in the `add_transaction`
-/// HTTP method.
+impl ExternalDeployAccountTransactionV3 {
+    fn into_internal(self, chain_id: &ChainId) -> InternalDeployAccountTransaction {
+        let tx = crate::transaction::DeployAccountTransaction::V3(
+            crate::transaction::DeployAccountTransactionV3 {
+                resource_bounds: self.resource_bounds,
+                tip: self.tip,
+                paymaster_data: self.paymaster_data,
+                nonce_data_availability_mode: self.nonce_data_availability_mode,
+                fee_data_availability_mode: self.fee_data_availability_mode,
+                signature: self.signature,
+                nonce: self.nonce,
+                class_hash: self.class_hash,
+                constructor_calldata: self.constructor_calldata.clone(),
+                contract_address_salt: self.contract_address_salt,
+            },
+        );
+
+        let tx_hash = tx.calculate_transaction_hash(chain_id, &TransactionVersion::THREE).unwrap();
+        let contract_address = calculate_contract_address(
+            self.contract_address_salt,
+            self.class_hash,
+            &self.constructor_calldata,
+            ContractAddress::default(),
+        )
+        .unwrap();
+
+        InternalDeployAccountTransaction { tx, tx_hash, contract_address, only_query: false }
+    }
+}
 #[derive(Clone, Debug, Deserialize, Eq, PartialEq, Serialize)]
 #[serde(deny_unknown_fields)]
 pub struct ExternalInvokeTransactionV3 {
@@ -116,6 +205,27 @@ pub struct ExternalInvokeTransactionV3 {
     pub account_deployment_data: AccountDeploymentData,
 }
 
+impl ExternalInvokeTransactionV3 {
+    fn into_internal(self, chain_id: &ChainId) -> InternalInvokeTransaction {
+        let tx =
+            crate::transaction::InvokeTransaction::V3(crate::transaction::InvokeTransactionV3 {
+                resource_bounds: self.resource_bounds,
+                tip: self.tip,
+                signature: self.signature,
+                nonce: self.nonce,
+                sender_address: self.sender_address,
+                calldata: self.calldata,
+                nonce_data_availability_mode: self.nonce_data_availability_mode,
+                fee_data_availability_mode: self.fee_data_availability_mode,
+                paymaster_data: self.paymaster_data,
+                account_deployment_data: self.account_deployment_data,
+            });
+
+        let tx_hash = tx.calculate_transaction_hash(chain_id, &TransactionVersion::THREE).unwrap();
+        InternalInvokeTransaction { tx, tx_hash, only_query: false }
+    }
+}
+
 #[derive(Clone, Debug, Default, Deserialize, Eq, PartialEq, Serialize)]
 pub struct ContractClass {
     #[serde(rename = "sierra_program")]
@@ -123,4 +233,8 @@ pub struct ContractClass {
     pub contract_class_version: String,
     pub entry_points_by_type: HashMap<EntryPointType, Vec<EntryPoint>>,
     pub abi: String,
+}
+
+fn calculate_class_hash() -> ClassHash {
+    todo!()
 }

--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -23,7 +23,7 @@ use crate::transaction_hash::{
 };
 use crate::StarknetApiError;
 
-trait TransactionHasher {
+pub(crate) trait TransactionHasher {
     fn calculate_transaction_hash(
         &self,
         chain_id: &ChainId,


### PR DESCRIPTION
- add `into_internal` method that consumes external tx and creates an internal (not using From in order to better emphasize the importance of this method in the API)
- refactor: remove repetition in docstrings.
- Add useful derives for internal txs.

Continuation of: https://reviewable.io/reviews/starkware-libs/starknet-api/222

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-api/230)
<!-- Reviewable:end -->
