### PR TITLE
chore: derive enum-iter for builtin enum

### DIFF
--- a/src/transaction.rs
+++ b/src/transaction.rs
@@ -1,3 +1,7 @@
+#[cfg(test)]
+#[path = "transaction_test.rs"]
+mod transaction_test;
+
 use std::collections::{BTreeMap, HashMap, HashSet};
 use std::fmt::Display;
 use std::sync::Arc;
@@ -925,24 +929,26 @@ pub struct ExecutionResources {
     pub da_l1_data_gas_consumed: u64,
 }
 
+/// The order of the builtins in this enum is important for EnumIter.
+/// This is the order of builtins the Starknet OS expects.
 #[derive(Clone, Debug, Deserialize, EnumIter, Eq, Hash, PartialEq, Serialize)]
 pub enum Builtin {
-    #[serde(rename = "range_check_builtin_applications")]
-    RangeCheck,
     #[serde(rename = "pedersen_builtin_applications")]
     Pedersen,
-    #[serde(rename = "poseidon_builtin_applications")]
-    Poseidon,
-    #[serde(rename = "ec_op_builtin_applications")]
-    EcOp,
+    #[serde(rename = "range_check_builtin_applications")]
+    RangeCheck,
     #[serde(rename = "ecdsa_builtin_applications")]
     Ecdsa,
     #[serde(rename = "bitwise_builtin_applications")]
     Bitwise,
-    #[serde(rename = "keccak_builtin_applications")]
-    Keccak,
+    #[serde(rename = "ec_op_builtin_applications")]
+    EcOp,
+    #[serde(rename = "poseidon_builtin_applications")]
+    Poseidon,
     #[serde(rename = "segment_arena_builtin")]
     SegmentArena,
+    #[serde(rename = "keccak_builtin_applications")]
+    Keccak,
 }
 
 const RANGE_CHACK_BUILTIN_NAME: &str = "range_check";

--- a/src/transaction_test.rs
+++ b/src/transaction_test.rs
@@ -1,0 +1,22 @@
+use strum::IntoEnumIterator;
+
+use crate::transaction::Builtin;
+
+#[test]
+fn test_builtin_enum_order() {
+    let expected_builtin_order = [
+        // Builtins that are allowed for direct use by contracts on Starknet.
+        Builtin::Pedersen,
+        Builtin::RangeCheck,
+        Builtin::Ecdsa,
+        Builtin::Bitwise,
+        Builtin::EcOp,
+        Builtin::Poseidon,
+        Builtin::SegmentArena,
+        // Builtins that are not allowed for direct use by contracts on Starknet (They are allowed
+        // for indirect use, for example, by syscall).
+        Builtin::Keccak,
+    ];
+    let from_iter = Builtin::iter().collect::<Vec<Builtin>>();
+    assert_eq!(&from_iter, &expected_builtin_order);
+}


### PR DESCRIPTION
Similar to #290. 

Linked part of the discussion from that PR:
@yair-starkware : Changing the order requires  a storage migration in Papyrus
@dan-starkware : We are during a major storage version change as it is. So if this can be merged into papyrus before the 13.2 corresponding version we should be fine

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-api/293)
<!-- Reviewable:end -->
