### PR TITLE
feat: add PartialEq to StarknetApiError

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,7 +22,8 @@ use std::num::ParseIntError;
 use serde_utils::InnerDeserializationError;
 
 /// The error type returned by StarknetApi.
-#[derive(thiserror::Error, Clone, Debug)]
+// Note: if you need `Eq` see InnerDeserializationError's docstring.
+#[derive(thiserror::Error, Clone, Debug, PartialEq)]
 pub enum StarknetApiError {
     /// Error in the inner deserialization of the node.
     #[error(transparent)]

--- a/src/serde_utils.rs
+++ b/src/serde_utils.rs
@@ -76,7 +76,15 @@ impl<const N: usize, const PREFIXED: bool> Serialize for BytesAsHex<N, PREFIXED>
 }
 
 /// The error type returned by the inner deserialization.
-#[derive(thiserror::Error, Clone, Debug)]
+// If you need `eq`, add `impl Eq fro InnerDeserializationError {}` and read warning below.
+//
+// For some reason `hex` (now unmaintained for > 3 years) didn't implement `Eq`, even though
+// there's no reason not too, so we can't use `derive(Eq)` unfortunately.
+// Note that adding the impl is risky, because if at some point `hex` decide to add non-Eq
+// things to the error, then combined with the manual `impl Eq` this will create very nasty bugs.
+// So, for prudence, we'll hold off on adding `Eq` until we have a good reason to.
+// Existing (ignored) issue on this: https://github.com/KokaKiwi/rust-hex/issues/76.
+#[derive(thiserror::Error, Clone, Debug, PartialEq)]
 pub enum InnerDeserializationError {
     /// Error parsing the hex string.
     #[error(transparent)]


### PR DESCRIPTION
This will mainly help test writers, who can now `assert_eq!` on `StarknetApiResult`s.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/starkware-libs/starknet-api/296)
<!-- Reviewable:end -->
